### PR TITLE
Add config.allow-plugins

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,6 +23,10 @@
             "phpcs": "Analyze code against the WordPress coding standards with PHP_CodeSniffer",
             "phpcb": "Fix coding standards warnings/errors automatically with PHP Code Beautifier"
       }
+    },
+    "config": {
+        "allow-plugins": {
+            "dealerdirect/phpcodesniffer-composer-installer": true
+        }
     }
-  }
-  
+}


### PR DESCRIPTION
This fixes: https://github.com/PHPCSStandards/composer-installer/issues/185
See also https://blog.packagist.com/composer-2-2/#more-secure-plugin-execution